### PR TITLE
Polish: Remove unneeded files

### DIFF
--- a/org.chromium.Chromium.BaseApp.yaml
+++ b/org.chromium.Chromium.BaseApp.yaml
@@ -54,6 +54,8 @@ modules:
   - name: krb5
     subdir: src
     config-opts:
+      - --localstatedir=/var/lib
+      - --sbindir=${FLATPAK_DEST}/bin
       - --disable-static
       - --disable-rpath
     sources:
@@ -69,6 +71,12 @@ modules:
         dest: src
         commands:
           - autoreconf -si
+    cleanup:
+      - /bin
+      - /lib/pkgconfig
+      - /share/et
+      - /share/examples
+      - /share/man
 
   - name: krb5-config
     buildsystem: simple

--- a/org.chromium.Chromium.BaseApp.yaml
+++ b/org.chromium.Chromium.BaseApp.yaml
@@ -16,6 +16,7 @@ modules:
       - /include
       - /lib/pkgconfig
       - /share/gir-1.0
+      - /lib/girepository-1.0
       - /share/man
     sources:
       - type: archive


### PR DESCRIPTION
* ~~Keep headers and pkgconfig files in baseapp, so it would be possible to build Chromium from source with it.~~
* ~~Add `cleanup-BaseApp.sh` so apps would be able to remove these development files. App maintainers are expected to add the following to the app's manifest.~~
```
cleanup-commands:
  - /app/cleanup-BaseApp.sh
```
* krb5: Remove unneeded files. This was already tested in flathub/com.google.Chrome/pull/105, though I'm not sure about removing gettext translation files, as I saw gettext function call in krb5 lib's source.
* libsecret: Remove GIR typelib file. As far as I can tell, it's not needed.