### PR TITLE
Update libsecret and use GnuTLS backend instead of pinning

### DIFF
--- a/org.chromium.Chromium.BaseApp.yaml
+++ b/org.chromium.Chromium.BaseApp.yaml
@@ -9,19 +9,20 @@ modules:
     buildsystem: meson
     config-opts:
       - -Dmanpage=false
+      - -Dcrypto=gnutls
       - -Dvapi=false
       - -Dgtk_doc=false
+      - -Dintrospection=false
+      - -Dbash_completion=disabled
     cleanup:
       - /bin
       - /include
       - /lib/pkgconfig
-      - /share/gir-1.0
-      - /lib/girepository-1.0
       - /share/man
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/libsecret/0.19/libsecret-0.19.1.tar.xz
-        sha256: 8583e10179456ae2c83075d95455f156dc08db6278b32bf4bd61819335a30e3a
+        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.4.tar.xz
+        sha256: 163d08d783be6d4ab9a979ceb5a4fecbc1d9660d3c34168c581301cd53912b20
 
   - name: krb5
     subdir: src


### PR DESCRIPTION
This should be the same as pinning it on an older version and not using the libgcrypt backend