### PR TITLE
libsecret: Disable crypto backends

### DIFF
--- a/org.chromium.Chromium.BaseApp.yaml
+++ b/org.chromium.Chromium.BaseApp.yaml
@@ -9,7 +9,7 @@ modules:
     buildsystem: meson
     config-opts:
       - -Dmanpage=false
-      - -Dcrypto=gnutls
+      - -Dcrypto=disabled
       - -Dvapi=false
       - -Dgtk_doc=false
       - -Dintrospection=false


### PR DESCRIPTION
We want to use the DBus backend as both gnutls and libgcrypt options use the file backend

Fixes b496ea9a7f5b631f2f7cbfcb68a509707f6a05db