### PR TITLE
Revert cleanup changes from previous PR

### DIFF
--- a/org.chromium.Chromium.BaseApp.yaml
+++ b/org.chromium.Chromium.BaseApp.yaml
@@ -4,9 +4,6 @@ runtime: org.freedesktop.Platform
 runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 separate-locales: false
-cleanup:
-  - /include
-  - /lib/pkgconfig
 modules:
 
   - name: libsecret
@@ -20,6 +17,8 @@ modules:
       - -Dbash_completion=disabled
     cleanup:
       - /bin
+      - /include
+      - /lib/pkgconfig
       - /share/man
     sources:
       - type: archive
@@ -48,6 +47,7 @@ modules:
           - autoreconf -si
     cleanup:
       - /bin
+      - /lib/pkgconfig
       - /share/et
       - /share/examples
       - /share/man

--- a/org.chromium.Chromium.BaseApp.yaml
+++ b/org.chromium.Chromium.BaseApp.yaml
@@ -47,7 +47,6 @@ modules:
           - autoreconf -si
     cleanup:
       - /bin
-      - /lib/pkgconfig
       - /share/et
       - /share/examples
       - /share/man


### PR DESCRIPTION
This reverts the cleanup changes in #47.

It turns out krb5 headers are needed for building Chromium.